### PR TITLE
Adds battery metric

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -124,15 +124,17 @@ func (collector *deconzCollector) Collect(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		if battery, ok := batteryByName[l.Name]; ok {
-			if l.Config.Battery != battery {
-				zap.L().Warn("Battery value differs on identical name",
-					zap.String("name", l.Name),
-					zap.String("uniqueid", l.UniqueID),
-				)
+		if l.Config.Battery > 0 {
+			if battery, ok := batteryByName[l.Name]; ok {
+				if l.Config.Battery != battery {
+					zap.L().Warn("Battery value differs on identical name",
+						zap.String("name", l.Name),
+						zap.String("uniqueid", l.UniqueID),
+					)
+				}
 			}
+			batteryByName[l.Name] = l.Config.Battery
 		}
-		batteryByName[l.Name] = l.Config.Battery
 
 		if l.Type == "ZHATemperature" {
 			ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Fixes #2

Currently includes the virtual `Daylight` sensor from ConbeeII. The value is 0. I suppose I could simply omit zero values, as it is difficult to imagine a sensor being on battery=0 that is still online. What do you think @hawkaa? Feel free to test `solsson/prometheus-deconz-exporter:54f75098c44aa77f51360a30693c37e3a330015f@sha256:8ee87f2894ed015153caeedc76ef86802a68a3a781c448fd6949da12dd9a3351`

I don't know yet what these values are worth. I have an old battery reporting 78 while one that's a week old reports 88 and another that's week old but sits outside in about 0 degrees C reports 68. An old battery in an Aquara motion sensor reports 100. I suppose trends are interesting.